### PR TITLE
Add privacy policy tos pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,6 +12,7 @@ import { Profile } from "./Pages/Profile/Profile";
 import { Article } from "./Pages/Article/Article";
 import ScrollToTop from "./Components/ScrollToTop/ScrollToTop";
 import { PrivacyPolicy } from "./Pages/PrivacyPolicy/PrivacyPolicy";
+import { TermsOfService } from "./Pages/TermsOfService/TermsOfService"
 import { Test } from "./Components/Test/Test";
 
 function App() {
@@ -39,6 +40,7 @@ function App() {
               <Route path="/login" element={<LoginPage />} />
               <Route path="/profile" element={<Profile />} />
               <Route path="/privacypolicy" element={<PrivacyPolicy />} />
+              <Route path="/termsofservice" element={<TermsOfService />} />
               <Route path="/test" element={<Test />} />
             </Routes>
           </ScrollToTop>

--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ import { News } from "./Pages/News/News";
 import { Profile } from "./Pages/Profile/Profile";
 import { Article } from "./Pages/Article/Article";
 import ScrollToTop from "./Components/ScrollToTop/ScrollToTop";
+import { PrivacyPolicy } from "./Pages/PrivacyPolicy/PrivacyPolicy";
 import { Test } from "./Components/Test/Test";
 
 function App() {
@@ -37,6 +38,7 @@ function App() {
               <Route path="/News/:title" element={<Article />} />
               <Route path="/login" element={<LoginPage />} />
               <Route path="/profile" element={<Profile />} />
+              <Route path="/privacypolicy" element={<PrivacyPolicy />} />
               <Route path="/test" element={<Test />} />
             </Routes>
           </ScrollToTop>

--- a/src/Pages/PrivacyPolicy/PrivacyPolicy.css
+++ b/src/Pages/PrivacyPolicy/PrivacyPolicy.css
@@ -1,0 +1,39 @@
+.main-container {
+  padding: 5em 8.5em 5em 8.5em;
+}
+
+.title {
+  font-size: 4em;
+  color: black;
+  text-align: start;
+}
+
+.sub-title {
+  font-size: 0.85em;
+  color: var(--color-text-alt);
+  text-align: start;
+  padding-left: 0.2em;
+}
+
+.effective-date {
+  margin-top: 2em;
+  margin-bottom: 1em;
+  text-align: left;
+}
+
+.display-linebreake {
+  white-space: pre-line;
+}
+
+.main-template {
+  text-align: start;
+}
+
+.show-list-style {
+  list-style-type: circle;
+  margin-left: 1em;
+}
+
+.template-title {
+  padding-bottom: 0.25em;
+}

--- a/src/Pages/PrivacyPolicy/PrivacyPolicy.css
+++ b/src/Pages/PrivacyPolicy/PrivacyPolicy.css
@@ -3,7 +3,7 @@
 }
 
 .title {
-  font-size: 4em;
+  font-size: 3.5em;
   color: black;
   text-align: start;
 }

--- a/src/Pages/PrivacyPolicy/PrivacyPolicy.js
+++ b/src/Pages/PrivacyPolicy/PrivacyPolicy.js
@@ -1,0 +1,14 @@
+import "./PrivacyPolicy.css";
+import Template from "./Template";
+
+const PrivacyPolicy = (props) => (
+  <div className="main-container">
+    <h1 className="title">Privacy Policy</h1>
+    <h3 className="sub-title">Last Updated Jun 1st, 2023 </h3>
+    <p className="effective-date">Effective Date: [Date]</p>
+
+    <Template meta={props} />
+  </div>
+);
+
+export { PrivacyPolicy };

--- a/src/Pages/PrivacyPolicy/PrivacyPolicy.js
+++ b/src/Pages/PrivacyPolicy/PrivacyPolicy.js
@@ -6,7 +6,6 @@ const PrivacyPolicy = (props) => (
     <h1 className="title">Privacy Policy</h1>
     <h3 className="sub-title">Last Updated Jun 1st, 2023 </h3>
     <p className="effective-date">Effective Date: [Date]</p>
-
     <Template meta={props} />
   </div>
 );

--- a/src/Pages/PrivacyPolicy/Template.js
+++ b/src/Pages/PrivacyPolicy/Template.js
@@ -1,0 +1,82 @@
+const Template = () => (
+  <div className="main-template">
+    <p>This Privacy Policy explains how we collect, use, disclose, and safeguard your personal information when you use our book reader application (the "App"). Please read this Privacy Policy carefully. By using the App, you consent to the collection, use, and disclosure of your personal information as described in this Privacy Policy.</p>
+    <br />
+    <h2>I. Information We Collect</h2>
+    <p>We may collect certain personal information from you when you use the App. The information we collect may include:</p>
+    <br />
+    <ul>
+      <li>Information You Provide to Us:
+        <ul>
+          <li className="show-list-style">Personal and contact information such as your name and email address, which you voluntarily provide when creating an account or contacting us for support.</li>
+          <li className="show-list-style">Payment information when you make purchases within the App, such as your credit card details. Please note that we do not store your payment information directly but rely on secure third-party payment processors.</li>
+        </ul>
+      </li>
+      <br />
+      <li>Information Collected Automatically:
+        <ul>
+          <li className="show-list-style">Usage information, including the dates and times you access the App, the features you use, and your interactions with the App.</li>
+          <li className="show-list-style">Device information, such as your IP address, device type, operating system, and mobile network information.</li>
+        </ul>
+      </li>
+    </ul>
+    <br />
+    <h2>II. How We Use Your Information</h2>
+    <p>We may use the information we collect from you for the following purposes:</p>
+    <br />
+    <ul>
+      <li>To Provide and Improve the App:
+        <ul>
+          <li className="show-list-style">To operate, maintain, and enhance the functionality of the App.</li>
+          <li className="show-list-style">To personalize your experience and provide you with customized content and recommendations.</li>
+        </ul>
+      </li>
+      <br />
+      <li>To Communicate with You:
+        <ul>
+          <li className="show-list-style">To respond to your inquiries, provide support, and address any issues you may have.</li>
+          <li className="show-list-style">To send you administrative messages, updates, and promotional materials related to the App.</li>
+        </ul>
+      </li>
+      <br />
+      <li>To Ensure Compliance and Protect Our Rights:
+        <ul>
+          <li className="show-list-style">To enforce our terms of service and other policies.</li>
+          <li className="show-list-style">To detect and prevent fraud, unauthorized access, or other illegal activities.</li>
+        </ul>
+      </li>
+    </ul>
+    <br />
+    <h2>III. How We Disclose Your Information</h2>
+    <p>We may disclose your personal information in the following circumstances:</p>
+    <br />
+    <ul>
+      <li>Service Providers:
+        <ul>
+          <li className="show-list-style">We may share your information with third-party service providers who perform services on our behalf, such as payment processing, data analysis, and customer support.</li>
+        </ul>
+      </li>
+      <br />
+      <li>Legal Requirements:
+        <ul>
+          <li className="show-list-style">We may disclose your information to comply with applicable laws, regulations, or legal processes, or to respond to valid requests from public and government authorities.</li>
+        </ul>
+      </li>
+    </ul>
+    <br />
+    <h2>IV. Data Security</h2>
+    <p>We prioritize the security of your personal information and take reasonable measures to protect it from unauthorized access, loss, misuse, or alteration. However, please note that no method of transmission over the internet or electronic storage is completely secure, and we cannot guarantee absolute security.</p>
+    <br />
+    <h2>V. Children's Privacy</h2>
+    <p>The App is not intended for use by individuals under the age of [minimum age]. We do not knowingly collect personal information from children. If you become aware that a child has provided us with personal information without parental consent, please contact us, and we will take steps to remove the information from our systems.</p>
+    <br />
+    <h2>VI. Updates to This Privacy Policy</h2>
+    <p>We may update this Privacy Policy from time to time. We will notify you of any changes by posting the updated Privacy Policy in the App or by other means. Please review this Privacy Policy periodically for any updates.</p>
+    <br />
+    <h2>VII. Contact Us</h2>
+    <p>If you have any questions or concerns about this Privacy Policy, please contact us at [contact information].</p>
+    <p>By using the App, you acknowledge that you have read and understood this Privacy Policy and agree to the collection, use, and disclosure of your personal information as described herein.</p>
+  </div >
+);
+
+export default Template;

--- a/src/Pages/TermsOfService/Template.js
+++ b/src/Pages/TermsOfService/Template.js
@@ -1,0 +1,79 @@
+const Template = () => (
+  <div className="main-template">
+
+    <h1 className="title">Terms of Service for Librum E-Book Reader</h1>
+
+    <p><em>Last updated: [Date]</em></p>
+
+    <p>Please read these Terms of Service ("Terms") carefully before using the Librum Book Reader Application ("Librum" or the "Application") provided by [Company Name] ("Company," "we," or "us"). By accessing or using Librum, you agree to be bound by these Terms. If you do not agree to these Terms, please do not use Librum.</p>
+    <br />
+    <h2>1. Account Registration</h2>
+
+    <p>1.1. In order to use Librum, you may need to create an account. You must provide accurate and complete information during the registration process. It is your responsibility to keep your account information secure and up to date. You must not share your account credentials with anyone else.</p>
+
+    <p>1.2. You must be at least [age] years old or the age of majority in your jurisdiction, whichever is higher, to use Librum. If you are under the applicable age, you may only use Librum under the supervision of a parent or legal guardian.</p>
+    <br />
+    <h2>2. License to Use Librum</h2>
+
+    <p>2.1. Subject to your compliance with these Terms, we grant you a limited, non-exclusive, non-transferable, and revocable license to use Librum for personal, non-commercial purposes.</p>
+
+    <p>2.2. You agree not to copy, modify, distribute, sell, lease, or sublicense Librum or any part thereof unless expressly permitted by these Terms or with our prior written consent.</p>
+
+    <p>2.3. You acknowledge that Librum and its contents are protected by intellectual property rights and other laws. You agree not to remove, alter, or obscure any copyright, trademark, or other proprietary notices displayed in Librum.</p>
+    <br />
+    <h2>3. Content</h2>
+
+    <p>3.1. Librum allows you to access and read digital books ("Content") that may be provided by us or third-party sources. You acknowledge that we do not guarantee the availability, accuracy, or quality of any Content.</p>
+
+    <p>3.2. You are solely responsible for any Content you upload, download, transmit, or otherwise make available through Librum. You represent and warrant that you have all necessary rights, licenses, and permissions to use and distribute such Content.</p>
+
+    <p>3.3. We reserve the right to remove or disable access to any Content that violates these Terms or infringes upon the rights of others without prior notice.</p>
+    <br />
+    <h2>4. User Conduct</h2>
+
+    <p>4.1. You agree to use Librum in compliance with applicable laws and regulations. You will not engage in any activity that is harmful, illegal, or violates the rights of others.</p>
+
+    <p>4.2. You will not attempt to gain unauthorized access to Librum, interfere with its operation, or disrupt its functionality.</p>
+
+    <p>4.3. You will not use Librum to transmit any unsolicited or unauthorized advertising, promotional materials, or spam.</p>
+    <br />
+    <h2>5. Privacy</h2>
+
+    <p>5.1. We respect your privacy and handle your personal information in accordance with our Privacy Policy, which is incorporated by reference into these Terms. By using Librum, you consent to the collection, use, and disclosure of your personal information as described in the Privacy Policy.</p>
+    <br />
+    <h2>6. Limitation of Liability</h2>
+
+    <p>6.1. To the maximum extent permitted by applicable law, we shall not be liable for any indirect, incidental, consequential, or exemplary damages arising out of or in connection with your use of Librum.</p>
+
+    <p>6.2. We make no warranties or representations, express or implied, regarding the availability, reliability, accuracy, or suitability of Librum for any purpose.</p>
+    <br />
+    <h2>7. Indemnification</h2>
+
+    <p>7.1. You agree to indemnify, defend, and hold harmless the Company and its officers, directors, employees, and agents from and against any claims, liabilities, damages, losses, and expenses, including reasonable attorneys' fees, arising out of or in connection with your use of Librum or violation of these Terms.</p>
+    <br />
+    <h2>8. Termination</h2>
+
+    <p>8.1. We reserve the right to suspend or terminate your access to Librum at any time and for any reason without prior notice.</p>
+
+    <p>8.2. Upon termination, all licenses and rights granted to you under these Terms will immediately cease, and you must stop using Librum.</p>
+    <br />
+    <h2>9. Modifications to the Terms</h2>
+
+    <p>9.1. We may update or modify these Terms from time to time at our sole discretion. Any changes will be effective upon posting the revised Terms within Librum.</p>
+
+    <p>9.2. Your continued use of Librum after the effective date of the revised Terms constitutes your acceptance of the changes.</p>
+    <br />
+    <h2>10. Governing Law</h2>
+
+    <p>10.1. These Terms shall be governed by and construed in accordance with the laws of [Jurisdiction], without regard to its conflict of laws principles.</p>
+    <br />
+    <h2>11. Contact Information</h2>
+
+    <p>11.1. If you have any questions or concerns regarding these Terms or Librum, please contact us at [contact email].</p>
+
+    <p>These Terms of Service were last updated on [Date].</p>
+
+  </div>
+);
+
+export { Template };

--- a/src/Pages/TermsOfService/TermsOfService.css
+++ b/src/Pages/TermsOfService/TermsOfService.css
@@ -1,0 +1,9 @@
+.main-container {
+  padding: 5em 8.5em 5em 8.5em;
+}
+
+.title {
+  font-size: 3em;
+  color: black;
+  text-align: start;
+}

--- a/src/Pages/TermsOfService/TermsOfService.js
+++ b/src/Pages/TermsOfService/TermsOfService.js
@@ -1,0 +1,7 @@
+const TermsOgfService = () => (
+  <div>
+    <h1>TermsOgfService</h1>
+  </div>
+);
+
+export default TermsOgfService;

--- a/src/Pages/TermsOfService/TermsOfService.js
+++ b/src/Pages/TermsOfService/TermsOfService.js
@@ -1,7 +1,10 @@
-const TermsOgfService = () => (
-  <div>
-    <h1>TermsOgfService</h1>
+import "./TermsOfService.css";
+import { Template } from "./Template";
+
+const TermsOfService = (props) => (
+  <div className="main-container">
+    <Template meta={props} />
   </div>
 );
 
-export default TermsOgfService;
+export { TermsOfService };


### PR DESCRIPTION
# Pull Request Description

As suggested by David, this PR addresses the first task by adding the necessary pages and corresponding routes to the app's Privacy Policy and Terms of Service (TOS).

## Changes made in this PR:

* Created new pages for the Privacy Policy and TOS.
* Added routes to navigate to the newly created pages.
* Please note that I have not added links to these pages yet, as I wanted to focus on creating the initial structure.

This PR serves as the initial step towards ensuring compliance and legal coverage for the app. Please review the changes and provide any feedback or suggestions. I opted for a template-text component which later we can customize and dynamically update with props.

## Privacy Policy
![image](https://github.com/Librum-Reader/Librum-Website/assets/58822719/8b9d513e-1199-45bd-9012-4bd98e69e6ad)

## TOS
![image](https://github.com/Librum-Reader/Librum-Website/assets/58822719/a3ea4749-8bb0-41f6-af21-2ef3d3bf0938)

