### PR TITLE
fix: Improve support page layout

### DIFF
--- a/src/Components/Form/Form.css
+++ b/src/Components/Form/Form.css
@@ -1,8 +1,3 @@
-.contact-form-title {
-  font-size: 1.75em;
-  /* text-align: center; */
-}
-
 .support-page-contact {
   display: flex;
   justify-content: center;
@@ -18,7 +13,7 @@
 }
 
 .support-page-contact-form .title {
-  font-size: 1.75em;
+  font-size: 2em;
   color: #946BDE;
   font-weight: 700;
 }
@@ -38,11 +33,9 @@
 .form-div input, textarea {
   width: 800px;
   border-radius: 0.25em;
-  padding: 1em;
+  padding: 1.25em;
 }
 
-/* .form-div p {
-  text-align: start;
-  border: 1px solid red;
-  w
-} */
+.btn-container button {
+  width: 16em;
+}

--- a/src/Components/Form/Form.css
+++ b/src/Components/Form/Form.css
@@ -1,0 +1,48 @@
+.contact-form-title {
+  font-size: 1.75em;
+  /* text-align: center; */
+}
+
+.support-page-contact {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 5em 0 5em 0;
+}
+
+.support-page-contact-form {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+}
+
+.support-page-contact-form .title {
+  font-size: 1.75em;
+  color: #946BDE;
+  font-weight: 700;
+}
+
+.form-div {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: fit-content;
+}
+
+.form-div p {
+  width: 100%;
+}
+
+.form-div input, textarea {
+  width: 800px;
+  border-radius: 0.25em;
+  padding: 1em;
+}
+
+/* .form-div p {
+  text-align: start;
+  border: 1px solid red;
+  w
+} */

--- a/src/Components/Form/Form.js
+++ b/src/Components/Form/Form.js
@@ -9,40 +9,16 @@ export const Form = () => {
 
   return (
     <div
-      style={{ margin: "100px auto 0", paddingBottom: "100px" }}
+      // style={{ margin: "100px auto 0", paddingBottom: "100px" }}
       className="support-page-contact"
     >
       <div className="support-page-contact-form">
-        <h2>Contact Us</h2>
         <p
-          style={
-            bg === "light"
-              ? { color: "var(--color-primary0)" }
-              : {
-                  color: "white",
-                }
-          }
+          className="title"
         >
-          Send us a message today
+          Send us a message 🔥!
         </p>
         <div className="form-div">
-          <p
-            style={
-              bg === "light"
-                ? { color: "var(--color-primary0)" }
-                : {
-                    color: "white",
-                  }
-            }
-            className="p-form"
-          >
-            Name
-          </p>
-          <input
-            style={bg === "light" ? { color: "black" } : { color: "white" }}
-            type="text"
-            placeholder="Enter your Name"
-          />
         </div>
         <div className="form-div">
           {" "}
@@ -51,8 +27,8 @@ export const Form = () => {
               bg === "light"
                 ? { color: "var(--color-primary0)" }
                 : {
-                    color: "white",
-                  }
+                  color: "white",
+                }
             }
             className="p-form"
           >
@@ -71,8 +47,8 @@ export const Form = () => {
               bg === "light"
                 ? { color: "var(--color-primary0)" }
                 : {
-                    color: "white",
-                  }
+                  color: "white",
+                }
             }
             className="p-form"
           >
@@ -89,9 +65,9 @@ export const Form = () => {
           <button className="btn btn-secondary">Submit </button>
         </div>
       </div>
-      <div className="support-page-contact-image">
+      {/* <div className="support-page-contact-image">
         <img src={pic} alt="" />
-      </div>
+      </div> */}
     </div>
   );
 };

--- a/src/Components/Form/Form.js
+++ b/src/Components/Form/Form.js
@@ -16,7 +16,7 @@ export const Form = () => {
         <p
           className="title"
         >
-          Send us a message 🔥!
+          Send us a message
         </p>
         <div className="form-div">
         </div>
@@ -61,8 +61,12 @@ export const Form = () => {
           />
         </div>
 
-        <div>
-          <button className="btn btn-secondary">Submit </button>
+        <div className="btn-container">
+          <button
+            className="submit btn btn-secondary"
+          >
+            Submit
+          </button>
         </div>
       </div>
       {/* <div className="support-page-contact-image">

--- a/src/Pages/Support/SupportPage.css
+++ b/src/Pages/Support/SupportPage.css
@@ -244,6 +244,8 @@
   width: 95%;
   margin: 0 auto;
 }
+
+
 .support-page-contact-form {
   display: flex;
   flex-direction: column;
@@ -289,8 +291,8 @@
   cursor: pointer;
 }
 .support-page-need-support {
-  margin: 40px auto !important;
-  margin-top: 50px;
+  margin: 12em auto !important;
+  margin-top: 10em;
   /* border: 1px solid white; */
 }
 

--- a/src/Pages/Support/SupportPage.js
+++ b/src/Pages/Support/SupportPage.js
@@ -52,34 +52,6 @@ export const SupportPage = ({ message, anchor, cards }) => {
 
         <SupportWays pics={[reason3, reason1, reason2]} cards={cards} />
       </div>
-      <div className="support-page-need-support">
-        <div>
-          <img src={bg === "dark" ? supportLight : supportDark} alt="" />
-          <div>
-            <h1 style={{ color: "var(--color-primary)" }}>Need Support?</h1>
-            <p
-              style={
-                bg === "light"
-                  ? {
-                    color: "var(--color-primary0)",
-                  }
-                  : {
-                    color: "white",
-                  }
-              }
-            >
-              Need Support with the software? Having issues with your login
-              account? Just send a message and we will get back to you as soon
-              as possible.
-              <span style={{ color: "var(--color-primary)" }}>
-                {" "}
-                Fill out our form below with the details of your concern
-              </span>
-            </p>
-          </div>
-        </div>
-      </div>
-
     </div>
   );
 };

--- a/src/Pages/Support/SupportPage.js
+++ b/src/Pages/Support/SupportPage.js
@@ -35,22 +35,23 @@ export const SupportPage = ({ message, anchor, cards }) => {
       style={
         bg === "light"
           ? {
-              backgroundColor: "white",
-              color: "var(--color-primary)",
-              paddingBottom: "100px;",
-            }
+            backgroundColor: "white",
+            color: "var(--color-primary)",
+            paddingBottom: "100px;",
+          }
           : {
-              backgroundColor: "#282c34",
-              color: "var(--color-primary)",
-              paddingBottom: "100px",
-            }
+            backgroundColor: "#282c34",
+            color: "var(--color-primary)",
+            paddingBottom: "100px",
+          }
       }
       className="container"
     >
+      <Form />
       <div className="supportPage-container">
+
         <SupportWays pics={[reason3, reason1, reason2]} cards={cards} />
       </div>
-
       <div className="support-page-need-support">
         <div>
           <img src={bg === "dark" ? supportLight : supportDark} alt="" />
@@ -60,11 +61,11 @@ export const SupportPage = ({ message, anchor, cards }) => {
               style={
                 bg === "light"
                   ? {
-                      color: "var(--color-primary0)",
-                    }
+                    color: "var(--color-primary0)",
+                  }
                   : {
-                      color: "white",
-                    }
+                    color: "white",
+                  }
               }
             >
               Need Support with the software? Having issues with your login
@@ -79,7 +80,6 @@ export const SupportPage = ({ message, anchor, cards }) => {
         </div>
       </div>
 
-      <Form />
     </div>
   );
 };


### PR DESCRIPTION
Pull Request Description

Changes made in this PR:
- Removing the “Need Support” illustration and text
- Move the “Contact Us” section to the top of the page, and the “Ways to Support Us” section to the bottom
- Remove the “Name” input field of the “Contact Us” form (The user should only provide his email)
- Remove the “Contact Us” title
- Replace the “Send us a message today” text with a nicer “Send us a message” text
