### PR TITLE
Removed unnecessary quotation mark in About page copy

### DIFF
--- a/src/Components/About/About.js
+++ b/src/Components/About/About.js
@@ -28,7 +28,7 @@ export const About = () => {
               <p>
                 We believe that software should be free and open source. All of
                 our software is publicly available for you, feel free to
-                contribute or suggest new features!
+                contribute or suggest new features!"
               </p>
             </div>
           </div>

--- a/src/Components/About/About.js
+++ b/src/Components/About/About.js
@@ -28,7 +28,7 @@ export const About = () => {
               <p>
                 We believe that software should be free and open source. All of
                 our software is publicly available for you, feel free to
-                contribute or suggest new features!"
+                contribute or suggest new features!
               </p>
             </div>
           </div>


### PR DESCRIPTION
About page text had an unnecessary quotation mark in its copy, at the end of the paragraph. Copy was changed from:

We believe that software should be free and open source. All of our software is publicly available for you, feel free to contribute or suggest new features!"

To:

We believe that software should be free and open source. All of our software is publicly available for you, feel free to contribute or suggest new features!